### PR TITLE
Schema.json drop 'required' for security contexts

### DIFF
--- a/charts/operaton/values.schema.json
+++ b/charts/operaton/values.schema.json
@@ -414,14 +414,14 @@
       "type": "object",
       "properties": {
         "fsGroup": {
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
-      },
-      "required": [
-        "fsGroup"
-      ]
+      }
     },
-"securityContext": {
+    "securityContext": {
       "type": "object",
       "properties": {
         "capabilities": {
@@ -435,23 +435,18 @@
                 }
               ]
             }
-          },
-          "required": [
-            "drop"
-          ]
+          }
         },
         "runAsNonRoot": {
           "type": "boolean"
         },
         "runAsUser": {
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
-      },
-      "required": [
-        "capabilities",
-        "runAsNonRoot",
-        "runAsUser"
-      ]
+      }
     },
     "resources": {
       "type": "object",


### PR DESCRIPTION
## Background

Platforms with security contexts (SCCs), such as Openshift (or OKD) require specific values for fsGroup or runAsUser.
The final values are namespace-dependent - a security feature of these platforms.
It would be rather messy to retrieve the dynamically required values from the platform and generate a custom value.yaml for each stage+namespace.

However, platforms using SCCs can set these values automatically, given they are non-present or set to NULL.

## The Problem

The values.schema.json sets these properties as 'required'.
If they are set to null, each helm command must use the `--skip-schema-validation` or fail.

## A possible solution

Dropping these fields to be 'required' - They can still be set, they still show up normally, but are nullable and support platforms with SCCs.